### PR TITLE
feat: push page title to dataLayer

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -20,14 +20,15 @@ export default function (ctx, inject) {
 
 <% if (options.pageTracking) { %>
   ctx.app.router.afterEach((to) => {
-    setImmediate(() => {
+    setTimeout(() => {
       ctx.$gtm.push(to.gtm || {
         routeName: to.name,
         pageType: 'PageView',
-        pageUrl: to.fullPath,
+				pageUrl: to.fullPath,
+				pageTitle: document.title,
         event: '<%= options.pageViewEventName %>'
-      })
-    })
+			})
+		}, 250)
   })
 <% } %>
 }


### PR DESCRIPTION
Push the page title to the datalayer so it can be used in google analytics along with the path.