### PR TITLE
chore(test): don't duplicate almost identical tests for spa/universal

### DIFF
--- a/test/module.test.js
+++ b/test/module.test.js
@@ -2,101 +2,57 @@ const path = require('path')
 const { setup, loadConfig, get, url } = require('@nuxtjs/module-test-utils')
 const defaultSettings = require(path.join(__dirname, '../', 'lib', 'defaults.js'))
 
-describe('Module (universal mode)', () => {
-  let nuxt
+const modes = ['universal', 'spa']
 
-  const nuxtConfig = loadConfig(__dirname, '../../example')
-  nuxtConfig.mode = 'universal'
+for (const mode of modes) {
+  describe(`Module (${mode} mode)`, () => {
+    let nuxt
 
-  const gtmId = nuxtConfig.gtm.id
-  const scriptId = nuxtConfig.gtm.scriptId || defaultSettings.scriptId
-  const noscriptId = nuxtConfig.gtm.noscriptId || defaultSettings.noscriptId
+    const nuxtConfig = loadConfig(__dirname, '../../example')
+    nuxtConfig.mode = mode
 
-  beforeAll(async () => {
-    ({ nuxt } = (await setup(nuxtConfig)))
-  }, 60000)
+    const gtmId = nuxtConfig.gtm.id
+    const scriptId = nuxtConfig.gtm.scriptId || defaultSettings.scriptId
+    const noscriptId = nuxtConfig.gtm.noscriptId || defaultSettings.noscriptId
 
-  afterAll(async () => {
-    await nuxt.close()
+    beforeAll(async () => {
+      ({ nuxt } = (await setup(nuxtConfig)))
+    }, 60000)
+
+    afterAll(async () => {
+      await nuxt.close()
+    })
+
+    test('Render', async () => {
+      const html = await get('/')
+      const expected = { universal: 'Works!', spa: 'Loading...' }[mode]
+      expect(html).toContain(expected)
+    })
+
+    test('Has GTM script', async () => {
+      const html = await get('/')
+      expect(html).toContain(`data-hid="${scriptId}"`)
+    })
+
+    test('Has GTM noscript', async () => {
+      const html = await get('/')
+      expect(html).toContain(`data-hid="${noscriptId}"`)
+    })
+
+    // test with real GTM id
+    test('GTM should be defined ($nuxt.$gtm)', async () => {
+      const window = await nuxt.renderAndGetWindow(url('/'))
+      expect(window.$nuxt.$gtm).toBeDefined()
+    })
+
+    test('Verifying duplicate GTM script', async () => {
+      const window = await nuxt.renderAndGetWindow(url('/'))
+
+      const headGtmScriptsExternal = window.document.querySelectorAll(`head script[src="https://www.googletagmanager.com/gtm.js?id=${gtmId}"]`)
+      const headGtmScriptsHid = window.document.querySelectorAll(`head script[data-hid="${scriptId}"]`)
+      const totalAmoutOfGtmScriptsAtHead = headGtmScriptsExternal.length + headGtmScriptsHid.length
+
+      expect(totalAmoutOfGtmScriptsAtHead).toBeLessThan(3)
+    })
   })
-
-  test('Render', async () => {
-    const html = await get('/')
-    expect(html).toContain('Works!')
-  })
-
-  test('Has GTM script', async () => {
-    const html = await get('/')
-    expect(html).toContain(`data-hid="${scriptId}"`)
-  })
-
-  test('Has GTM noscript', async () => {
-    const html = await get('/')
-    expect(html).toContain(`data-hid="${noscriptId}"`)
-  })
-
-  // test with real GTM id
-  test('GTM should be defined ($nuxt.$gtm)', async () => {
-    const window = await nuxt.renderAndGetWindow(url('/'))
-    expect(window.$nuxt.$gtm).toBeDefined()
-  })
-
-  test('Verifying duplicate GTM script', async () => {
-    const window = await nuxt.renderAndGetWindow(url('/'))
-
-    const headGtmScriptsExternal = window.document.querySelectorAll(`head script[src="https://www.googletagmanager.com/gtm.js?id=${gtmId}"]`)
-    const headGtmScriptsHid = window.document.querySelectorAll(`head script[data-hid="${scriptId}"]`)
-    const totalAmoutOfGtmScriptsAtHead = headGtmScriptsExternal.length + headGtmScriptsHid.length
-
-    expect(totalAmoutOfGtmScriptsAtHead).toBeLessThan(3)
-  })
-})
-
-describe('Module (spa mode)', () => {
-  let nuxt
-
-  const nuxtConfig = loadConfig(__dirname, '../../example')
-  nuxtConfig.mode = 'spa'
-
-  const gtmId = nuxtConfig.gtm.id
-  const scriptId = nuxtConfig.gtm.scriptId || defaultSettings.scriptId
-  const noscriptId = nuxtConfig.gtm.noscriptId || defaultSettings.noscriptId
-
-  beforeAll(async () => {
-    ({ nuxt } = (await setup(nuxtConfig)))
-  }, 60000)
-
-  afterAll(async () => {
-    await nuxt.close()
-  })
-
-  test('Render', async () => {
-    const html = await get('/')
-    expect(html).toContain('Loading...')
-  })
-
-  test('Has GTM script', async () => {
-    const html = await get('/')
-    expect(html).toContain(`data-hid="${scriptId}"`)
-  })
-
-  test('Has GTM noscript', async () => {
-    const html = await get('/')
-    expect(html).toContain(`data-hid="${noscriptId}"`)
-  })
-
-  test('GTM should be defined ($nuxt.$gtm)', async () => {
-    const window = await nuxt.renderAndGetWindow(url('/'))
-    expect(window.$nuxt.$gtm).toBeDefined()
-  })
-
-  test('Verifying duplicate GTM script', async () => {
-    const window = await nuxt.renderAndGetWindow(url('/'))
-
-    const headGtmScriptsExternal = window.document.querySelectorAll(`head script[src="https://www.googletagmanager.com/gtm.js?id=${gtmId}"]`)
-    const headGtmScriptsHid = window.document.querySelectorAll(`head script[data-hid="${scriptId}"]`)
-    const totalAmoutOfGtmScriptsAtHead = headGtmScriptsExternal.length + headGtmScriptsHid.length
-
-    expect(totalAmoutOfGtmScriptsAtHead).toBeLessThan(3)
-  })
-})
+}


### PR DESCRIPTION
Combined both test blocks into one. The only difference between tests
is in `Render` test. Handled that by providing different expectations
depending on mode.