### PR TITLE
fix(module): check respectDoNotTrack option value

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -38,7 +38,9 @@ module.exports = async function gtmModule (_options) {
 
   const injectScript = `var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.${options.scriptDefer ? 'defer' : 'async'}=true;j.src='${options.scriptURL + '?id=\'+i' + (queryString ? (`+'&${queryString}` + '\'') : '')};f.parentNode.insertBefore(j,f)` // deps: d,s,i
 
-  let script = `${initLayer};w[x]={};w._gtm_inject=function(i){if(w.doNotTrack||w[x][i])return;w[x][i]=1;${injectScript};}`
+  const doNotTrackScript = options.respectDoNotTrack ? 'if(w.doNotTrack||w[x][i])return;' : ''
+
+  let script = `${initLayer};w[x]={};w._gtm_inject=function(i){${doNotTrackScript}w[x][i]=1;${injectScript};}`
 
   if (options.autoInit && options.id) {
     script += `;w[y]('${options.id}')`


### PR DESCRIPTION
It seems like `respectDoNotTrack` option is not used anywhere despite the fact README explains it is one of the options. 

So I assumed checking `respectDoNotTrack` value logic needs to be put right before generating the script that includes the following syntax.

```
if(w.doNotTrack||w[x][i])return;
```