### PR TITLE
fix(plugin): load SSR events before container loaded

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -12,7 +12,7 @@ function gtmClient(ctx, initialized) {
     },
     push(obj) {
       if (!window[_layer]) {
-        window[_layer] = [{ 'gtm.start': new Date().getTime(), event: 'gtm.js' }]
+        window[_layer] = []
       }
       window[_layer].push(obj)
     }
@@ -29,6 +29,8 @@ function gtmServer(ctx, initialized) {
     }
 
     const gtmScript = ctx.app.head.script.find(s => s.hid = '<%= options.scriptId %>')
+    gtmScript.innerHTML = `window['${_layer}']=${JSON.stringify(events)};${gtmScript.innerHTML}`
+
     if (inits.length) {
       gtmScript.innerHTML += `;${JSON.stringify(inits)}.forEach(function(i){window._gtm_inject(i)})`
     }
@@ -39,9 +41,6 @@ function gtmServer(ctx, initialized) {
       gtmIframe.innerHTML += inits.map(renderIframe)
     }
 <% } %>
-    if (events.length) {
-      gtmScript.innerHTML += `;${JSON.stringify(events)}.forEach(function(e){window['${_layer}'].push(e)})`
-    }
   })
 
   return {


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/162986/86517016-c23bfc80-be25-11ea-9fe7-681a32b09b6a.png)

after:
![image](https://user-images.githubusercontent.com/162986/86516977-6b362780-be25-11ea-94cd-ba38a4a171fa.png)

This can be useful when migrating from a legacy site and want to add some data from server side before the gtm container loads. I didn't find any other way to do this with the current code and Google also states that the dataLayer vaiable should be defined before the container script https://developers.google.com/tag-manager/devguide#adding-data-layer-variables-to-a-page