### PR TITLE
fix(module): allow client side push before init

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -56,13 +56,12 @@ module.exports = async function gtmModule (_options) {
     .join('&')
 
   // Compile scripts
-  const initLayer = "w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'})" // deps: w,l
-
   const injectScript = `var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.${options.scriptDefer ? 'defer' : 'async'}=true;j.src='${options.scriptURL + '?id=\'+i' + (queryString ? (`+'&${queryString}` + '\'') : '')};f.parentNode.insertBefore(j,f)` // deps: d,s,i
 
   const doNotTrackScript = options.respectDoNotTrack ? 'if(w.doNotTrack||w[x][i])return;' : ''
 
-  let script = `${initLayer};w[x]={};w._gtm_inject=function(i){${doNotTrackScript}w[x][i]=1;${injectScript};}`
+  const initLayer = "w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'})" // deps: w,l
+  let script = `w[x]={};w._gtm_inject=function(i){${doNotTrackScript}w[x][i]=1;${initLayer};${injectScript};}`
 
   if (options.autoInit && options.id) {
     script += `;w[y]('${options.id}')`


### PR DESCRIPTION
With this patch we can push client side events before the container loaded event:

```javascript
export default function gtmPlugin({ app, $gtm, $storage }) {
  if (app.$config.GTM_ID) {
    $gtm.push({ data: $storage.get('key') }); // this data only available in localstorage 
    $gtm.init(app.$config.GTM_ID);
  }
}
```
Kind of a follow up on https://github.com/nuxt-community/gtm-module/pull/51

This is the diff for the compiled script:

```diff
if (!window._gtm_init) {
  window._gtm_init = 1;
  (function (w, n, d, m, e, p) {
    w[d] = (w[d] == 1 || n[d] == 'yes' || n[d] == 1 || n[m] == 1 || (w[e] && w[e].p && e[e][p]())) ? 1 : 0
  })(window, 'navigator', 'doNotTrack', 'msDoNotTrack', 'external', 'msTrackingProtectionEnabled');
  (function (w, d, s, l, x, y) {
-   w[l] = w[l] || [];
-   w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
    w[x] = {};
    w._gtm_inject = function (i) {
      if (w.doNotTrack || w[x][i]) return;
      w[x][i] = 1;
+     w[l] = w[l] || [];
+     w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
      var f = d.getElementsByTagName(s)[0], j = d.createElement(s);
      j.async = true;
      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i;
      f.parentNode.insertBefore(j, f);
    }
  })(window, document, 'script', 'dataLayer', '_gtm_ids', '_gtm_inject')
}
```
