### PR TITLE
fix(plugin.mock): handle `event.eventCallback`

### DIFF
--- a/lib/plugin.mock.js
+++ b/lib/plugin.mock.js
@@ -27,6 +27,9 @@ export default function (ctx, inject) {
     },
     push: (event) => {
       log('push', process.client ? event : JSON.stringify(event))
+      if (typeof event.eventCallback === 'function') {
+        event.eventCallback()
+      }
     }
   }
 


### PR DESCRIPTION
if eventCallback was provided call it.
In some situations we need to call `eventCallback` on dev environment