### PR TITLE
fix: fix doNotTrack polyfill

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -4,7 +4,7 @@ const { requireNuxtVersion } = require('./compatibility')
 
 // doNotTrack polyfill
 // https://gist.github.com/pi0/a76fd97c4ea259c89f728a4a8ebca741
-const dnt = "(function(w,n,d,m,e,p){w[d]=(w[d]==1||n[d]=='yes'||n[d]==1||n[m]==1||(w[e]&&w[e].p&&e[e][p]()))?1:0})(window,'navigator','doNotTrack','msDoNotTrack','external','msTrackingProtectionEnabled')"
+const dnt = "(function(w,n,d,m,e,p){w[d]=(w[d]==1||n[d]=='yes'||n[d]==1||n[m]==1||(w[e]&&w[e].p&&e[e][p]()))?1:0})(window,navigator,'doNotTrack','msDoNotTrack','external','msTrackingProtectionEnabled')"
 
 module.exports = async function gtmModule (_options) {
   requireNuxtVersion(this.nuxt, '2.12.0')

--- a/lib/module.js
+++ b/lib/module.js
@@ -4,7 +4,7 @@ const { requireNuxtVersion } = require('./compatibility')
 
 // doNotTrack polyfill
 // https://gist.github.com/pi0/a76fd97c4ea259c89f728a4a8ebca741
-const dnt = "(function(w,n,d,m,e,p){w[d]=(w[d]==1||n[d]=='yes'||n[d]==1||n[m]==1||(w[e]&&w[e].p&&e[e][p]()))?1:0})(window,navigator,'doNotTrack','msDoNotTrack','external','msTrackingProtectionEnabled')"
+const dnt = "(function(w,n,d,m,e,p){w[d]=(w[d]==1||n[d]=='yes'||n[d]==1||n[m]==1||(w[e]&&w[e][p]&&w[e][p]()))?1:0})(window,navigator,'doNotTrack','msDoNotTrack','external','msTrackingProtectionEnabled')"
 
 module.exports = async function gtmModule (_options) {
   requireNuxtVersion(this.nuxt, '2.12.0')


### PR DESCRIPTION
# Issue Description
The `doNotTrack` pollyFill code snippet from https://gist.github.com/pi0/a76fd97c4ea259c89f728a4a8ebca741 is not working for me if `window.doNotTrack` is `0` but `navigator.doNotTrack` is `1`. That is Chrome behaviour, that means this DNT validation is not working for most of the users.

The parameter `n` get a string value `'navigator'`, which is used as an object in `n[d]` and `n[m]`. As a result, it returns `undefined` instead of expected result `1` or `0`.

# Solution
Change the argument to `navigator` instead of `'navigator'` fixes the issue for me.

I also found `window.external.msTrackingProtectionEnabled` part has mistake as well. Fixed in second commit.