### PR TITLE
fix: joined parts with '&amp;' instead of '&'

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -59,7 +59,7 @@ module.exports = async function gtmModule (_options) {
   const queryString = Object.keys(query)
     .filter(key => query[key] !== null && query[key] !== undefined)
     .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(query[key])}`)
-    .join('&')
+    .join('&amp;')
 
   // Compile scripts
   const injectScript = `var f=d.getElementsByTagName(s)[0],j=d.createElement(s);${options.crossOrigin ? 'j.crossOrigin=\'' + options.crossOrigin + '\';' : ''}j.${options.scriptDefer ? 'defer' : 'async'}=true;j.src='${options.scriptURL + '?id=\'+i' + (queryString ? (`+'&${queryString}` + '\'') : '')};f.parentNode.insertBefore(j,f)` // deps: d,s,i


### PR DESCRIPTION
joining options with only the `&` character results in a URL that google will respond to with status-code: 403.
The query-string parameters in Google's snippets are encoded with `&amp;` instead. 
Changing this results in the same url, differently encoded, which Google responds to with status code 200.