### PR TITLE
docs(README): add comment for where to set gtm_auth and gtm_preview params

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export default {
 
     id: undefined,
     layer: 'dataLayer',
-    variables: {},
+    variables: {}, /* scriptURL query params such as gtm_auth, gtm_preview can go here */
 
     pageTracking: false,
     pageViewEventName: 'nuxtRoute',


### PR DESCRIPTION
It is common to have `gtm_auth` and `gtm_preview` query params for non production environments. Adding this to the docs to make it clearer, as suggested in https://github.com/nuxt-community/gtm-module/issues/42