### PR TITLE
added unused GTM ID param as default value

### DIFF
--- a/lib/plugin.mock.js
+++ b/lib/plugin.mock.js
@@ -22,7 +22,7 @@ function startPageTracking (ctx) {
 export default function (ctx, inject) {
   log('Using mocked API. Real GTM events will not be reported.')
   const gtm = {
-    init: (id) => {
+    init: (id = _id) => {
       log('init', id)
     },
     push: (event) => {


### PR DESCRIPTION
Since this file has an unused import, I guess it was meant to be like this. I saw the same in `lib/plugin.js` and replicated the import usage.