### PR TITLE
chane document

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ export default {
   '@nuxtjs/gtm'
  ],
  plugins: [
-  '~/plugins/gtm'
+  { src: '~/plugins/gtm', mode: 'client' }
  ]
 }
 ```


### PR DESCRIPTION
hi, i think it's logical to load plugin in `client`, besides it has error in server side when fallow the document in `production`